### PR TITLE
added translation wrappers for string literals

### DIFF
--- a/de/catalog.json
+++ b/de/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Verknüpfe Dein Konto...",
     "loading": "Arbeitet noch..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "{{integrationName}} {{conversionFromCurrency}} zu {{conversionToCurrency}} Umrechnungsgebühr",
@@ -718,6 +721,12 @@
     "goBack": "Zurückgehen",
     "title": "Mit Krypto bezahlen"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Erlauben",
     "movingFunds": "Verschieben von Geldern ohne Ihre Erlaubnis",
@@ -779,6 +788,11 @@
     "transactionTitle": "Transaktion in Bearbeitung",
     "tryAgain": "Erneut versuchen"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Bitte geben Sie Ihr {{field}} ein",
     "fieldErrorWithIntegration": "Bitte geben Sie Ihr {{integrationName}} {{field}} ein",
@@ -815,6 +829,15 @@
     "selectAnotherExchange": "Bitte wählen Sie eine andere Börse oder Wallet, um eine Einzahlung vorzunehmen.",
     "selectNetwork": "Übertragsnetzwerk wählen",
     "title": "Zu übertragendes Asset auswählen"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Alle Gebühren enthalten",

--- a/en/catalog.json
+++ b/en/catalog.json
@@ -304,6 +304,9 @@
     "title": "Confirm your identity",
     "warningTitle": "Read this entire message before continuing."
   },
+  "errorHeadlines": {
+    "twoFaFailed": "Invalid 2FA Code"
+  },
   "errorMessages": {
     "amountBelowMinimum": "Requested amount is below the minimum allowable transfer amount on this network.",
     "amountExceedsMaximum": "Requested amount exceeds the maximum allowable transfer amount on this network.",
@@ -334,9 +337,6 @@
   },
   "errorPage": {
     "title": "An error has occurred."
-  },
-  "errorHeadlines": {
-    "twoFaFailed": "Invalid 2FA Code"
   },
   "exitPage": {
     "body": "Your progress will be lost.",
@@ -407,6 +407,9 @@
   "fullScreenSpinner": {
     "linking": "Linking your account...",
     "loading": "Still working..."
+  },
+  "fundingLoadingOverlay": {
+    "loading": "Loading..."
   },
   "fundingMethodFees": {
     "fee": {
@@ -722,6 +725,12 @@
     "goBack": "Go backwards",
     "title": "Pay with crypto"
   },
+  "networkSelectionDrawer": {
+    "description": "The networks below are all secure, compatible options for this payment. We’ve auto-selected the lowest fee network for you.",
+    "estimatedGasFeeLabel": "Est. gas fee:",
+    "lowestFeeLabel": "Lowest fee",
+    "title": "Select network"
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Allow",
     "movingFunds": "moving funds without your permission",
@@ -783,6 +792,11 @@
     "transactionTitle": "Transaction in progress",
     "tryAgain": "Try again"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "Merchant: {{clientName}}",
+    "title": "Order summary",
+    "totalLabel": "Total"
+  },
   "passwordPage": {
     "fieldError": "Please enter your {{field}}",
     "fieldErrorWithIntegration": "Please enter your {{integrationName}} {{field}}",
@@ -819,6 +833,15 @@
     "selectAnotherExchange": "Please select another exchange or wallet to deposit from.",
     "selectNetwork": "Select transfer network",
     "title": "Select asset to transfer"
+  },
+  "previewPageUI": {
+    "accountLabel": "Account",
+    "includeFeesMessage": "Includes {{amount}} in fees",
+    "networkLabel": "Network",
+    "paymentTitle": "Pay {{clientName}}",
+    "paymentTotalLabel": "Pay total",
+    "payWithLabel": "Pay with",
+    "payWithLabelWithName": "Pay with {{integrationName}}"
   },
   "previewTransfer": {
     "allFeesIncluded": "All fees included",

--- a/es/catalog.json
+++ b/es/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Vinculando tu cuenta...",
     "loading": "Espere por favor..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "Comisión de Conversión de {{integrationName}} {{conversionFromCurrency}} a {{conversionToCurrency}} ",
@@ -424,6 +427,7 @@
     "paymentMethodDepositUsage": "Forma de pago vinculada",
     "stablecoinConversion": "Conversión de stablecoin",
     "withAdditional_one": "{{mainOption}} + {{count}} otro",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} otros"
   },
   "fundingOptionUnavailabilityReason": {
@@ -718,6 +722,12 @@
     "goBack": "Retroceder",
     "title": "Pagar con cripto"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Permitir",
     "movingFunds": "mover tus fondos sin tu permiso",
@@ -779,6 +789,11 @@
     "transactionTitle": "Transacción en curso",
     "tryAgain": "Inténtalo de nuevo"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Por favor, captura tu {{field}}",
     "fieldErrorWithIntegration": "Por favor, captura tu {{integrationName}} {{field}}",
@@ -815,6 +830,15 @@
     "selectAnotherExchange": "Por favor, seleccione otro tipo de cambio o monedero del que depositar.",
     "selectNetwork": "Seleccionar red de transferencia",
     "title": "Seleccionar recurso a transferir"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Todas las comisiones incluidas",

--- a/fi/catalog.json
+++ b/fi/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Linkitetään tiliäsi...",
     "loading": "Työskentely jatkuu..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "{{integrationName}} {{conversionFromCurrency}} {{conversionToCurrency}} Muuntomaksu",
@@ -718,6 +721,12 @@
     "goBack": "Palaa taaksepäin",
     "title": "Maksaminen kryptolla"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Salli",
     "movingFunds": "varojen siirtäminen ilman lupaasi",
@@ -779,6 +788,11 @@
     "transactionTitle": "Tapahtuma työn alla",
     "tryAgain": "Yritä uudelleen"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Ole hyvä ja syötä {{field}}",
     "fieldErrorWithIntegration": "Ole hyvä ja syötä {{integrationName}} {{field}}",
@@ -815,6 +829,15 @@
     "selectAnotherExchange": "Valitse toinen pörssi tai lompakko tallettamiseen.",
     "selectNetwork": "Valitse siirtoverkko",
     "title": "Valitse siirrettävä omaisuus"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Kaikki maksut sisältyvät",

--- a/fr/catalog.json
+++ b/fr/catalog.json
@@ -1,6 +1,6 @@
 {
   "addressWhitelistPage": {
-    "addAddress": "Veuillez ajouter l’adresse suivante en tant qu’adresse approuvée pour les retraits :",
+    "addAddress": "Veuillez ajouter l’adresse suivante en tant qu’adresse approuvée pour les retraits\u00a0:",
     "goToAccount": "Accédez à votre compte <1>{{selectedIntegrationName}}</1>",
     "network": "Réseau",
     "preview": "Cliquez ci-dessous pour afficher l’aperçu et effectuer à nouveau le transfert",
@@ -15,7 +15,7 @@
   },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Le montant doit être compris entre {{minFiat}} {{selectedFiat}} - et {{maxFiat}} {{selectedFiat}}",
-    "amountMustBeWithinErrorMessage": "Le montant doit être compris entre 21 USD et 15 000 USD",
+    "amountMustBeWithinErrorMessage": "Le montant doit être compris entre 21\u00a0USD et 15\u00a0000\u00a0USD",
     "buyCrypto": "Acheter des crypto-monnaies via Binance Connect",
     "closeButton": "Fermer",
     "continueTo": "Continuer sur {{selectedIntegrationName}}",
@@ -38,7 +38,7 @@
     "description": "Pour sécuriser votre compte <1>Binance</1>, vous devez configurer à la fois votre adresse e-mail et une application d’authentification comme méthodes 2FA.",
     "ensureConfigured": "Assurez-vous que l’adresse e-mail et l’application d’authentification sont toutes les deux configurées pour 2FA",
     "goToSettings": "Cliquez ci-dessous pour accéder à vos paramètres de sécurité sur <1>Binance</1>",
-    "mayNeedReAuthApp": "Veuillez noter : vous devrez peut-être vous ré-authentifier sur votre compte Binance pour initier ce transfert lorsque vous retournerez à <2>l'application</2>.",
+    "mayNeedReAuthApp": "Veuillez noter\u00a0: vous devrez peut-être vous ré-authentifier sur votre compte Binance pour initier ce transfert lorsque vous retournerez à <2>l'application</2>.",
     "mayNeedReAuthClient": "Veuillez noter : vous devrez peut-être vous ré-authentifier sur votre compte Binance pour initier ce transfert lorsque vous retournerez à <2>{{clientName}}</2>.",
     "openBinance": "Ouvrir Binance",
     "returnToApp": "Retournez dans <1>l'application</1> pour réessayer à nouveau ce transfert",
@@ -47,10 +47,10 @@
   },
   "binanceResetPasswordPage": {
     "goToBinance": "Allez sur Binance.com",
-    "securityNote": "À savoir : pour des raisons de sécurité, les retraits en crypto sont désactivés pendant 24 heures après un changement de mot de passe.",
+    "securityNote": "À savoir\u00a0: pour des raisons de sécurité, les retraits en crypto sont désactivés pendant 24\u00a0heures après un changement de mot de passe.",
     "steps": {
       "completeProcess": "Complétez le processus pour réinitialiser votre mot de passe.",
-      "enterEmail": "Saisissez votre adresse e-mail ou votre numéro de téléphone, puis cliquez sur « Mot de passe oublié ? ».",
+      "enterEmail": "Saisissez votre adresse e-mail ou votre numéro de téléphone, puis cliquez sur «\u00a0Mot de passe oublié\u00a0?\u00a0».",
       "goToBinance": "Sélectionnez <1>Allez sur Binance.com</1> pour être redirigé vers l’écran de connexion Binance.",
       "returnToLogin": "Revenez ici pour vous reconnecter avec votre nouveau mot de passe."
     },
@@ -119,7 +119,7 @@
     "verificationCodeInputTitle": "Code de vérification"
   },
   "chooseAccountPage": {
-    "linkToApp": "Lequel de vos comptes souhaitez-vous que <1></1> lie à cette application ",
+    "linkToApp": "Lequel de vos comptes souhaitez-vous que <1></1> lie à cette application\u00a0",
     "linkToClient": "Lequel de vos comptes souhaitez-vous que <1></1> lie à {{clientName}}",
     "title": "Sélectionnez les sous-comptes"
   },
@@ -204,7 +204,7 @@
     "monitoringApproval": "En cours d’approbation...",
     "selectNetwork": "Sélectionnez le réseau",
     "title": "Changement de réseau",
-    "whichNetwork": "Quel réseau dans votre portefeuille <1>{{selectedIntegrationName}}</1><4></4>souhaitez-vous lier ?"
+    "whichNetwork": "Quel réseau dans votre portefeuille <1>{{selectedIntegrationName}}</1><4></4>souhaitez-vous lier\u00a0?"
   },
   "defiWalletUnavaialbleConnectionPage": {
     "body": "{{integrationName}} n'est pas installé sur cet appareil. Veuillez télécharger l'application {{integrationName}} ou connecter un autre portefeuille.",
@@ -404,6 +404,9 @@
     "linking": "Liaison de votre compte...",
     "loading": "Toujours en cours..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "Frais de conversion de {{integrationName}} de {{conversionFromCurrency}} à {{conversionToCurrency}}",
@@ -424,6 +427,7 @@
     "paymentMethodDepositUsage": "Méthode de paiement liée",
     "stablecoinConversion": "Conversion en stablecoin",
     "withAdditional_one": "{{mainOption}} + {{count}} autre",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} autres"
   },
   "fundingOptionUnavailabilityReason": {
@@ -718,6 +722,12 @@
     "goBack": "Revenir en arrière",
     "title": "Payer avec de la crypto"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Autoriser",
     "movingFunds": "déplacement de fonds sans votre permission",
@@ -779,6 +789,11 @@
     "transactionTitle": "Transaction en cours",
     "tryAgain": "Réessayez"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Veuillez entrer votre {{field}}",
     "fieldErrorWithIntegration": "Veuillez entrer votre {{integrationName}} {{field}}.",
@@ -815,6 +830,15 @@
     "selectAnotherExchange": "Veuillez sélectionner un autre échange ou portefeuille pour déposer.",
     "selectNetwork": "Sélectionner le réseau de transfert",
     "title": "Sélectionner l'actif à transférer"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Tous frais inclus",

--- a/hi/catalog.json
+++ b/hi/catalog.json
@@ -404,6 +404,9 @@
     "linking": "आपका खाता लिंक किया जा रहा है...",
     "loading": "अभी भी काम कर रहा है..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "{{integrationName}} {{conversionFromCurrency}} से {{conversionToCurrency}} रूपांतरण शुल्क",
@@ -718,6 +721,12 @@
     "goBack": "पीछे जाएं",
     "title": "क्रिप्टो के साथ भुगतान करें"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "अनुमति दें",
     "movingFunds": "आपकी अनुमति के बिना फंड हटाना",
@@ -779,6 +788,11 @@
     "transactionTitle": "लेन-देन प्रगति में है",
     "tryAgain": "फिर से प्रयास करें"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "कृपया अपना {{field}} दर्ज करें",
     "fieldErrorWithIntegration": "कृपया अपना {{integrationName}} {{field}} दर्ज करें",
@@ -815,6 +829,15 @@
     "selectAnotherExchange": "जमा करने के लिए कृपया अन्य एक्सचेंज या वॉलेट का चयन करें।",
     "selectNetwork": "स्थानांतरण नेटवर्क का चयन करें",
     "title": "स्थानांतरण के लिए संपत्ति चुनें"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "सभी शुल्क शामिल हैं",

--- a/ja/catalog.json
+++ b/ja/catalog.json
@@ -404,6 +404,9 @@
     "linking": "あなたのアカウントをリンクしています...",
     "loading": "まだ作業中です..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "{{integrationName}} {{conversionFromCurrency}} を{{conversionToCurrency}} に変換手数料",
@@ -718,6 +721,12 @@
     "goBack": "戻る",
     "title": "暗号資産で支払う"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "許可する",
     "movingFunds": "あなたの許可なしに資金を移動",
@@ -779,6 +788,11 @@
     "transactionTitle": "取引中",
     "tryAgain": "もう一度お試しください"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "{{field}}を入力してください。",
     "fieldErrorWithIntegration": "{{integrationName}} {{field}}を入力してください。",
@@ -815,6 +829,15 @@
     "selectAnotherExchange": "別の取引所またはウォレットからの入金を選択してください。",
     "selectNetwork": "転送ネットワークを選択",
     "title": "転送する資産を選択"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "全ての手数料が含まれています",

--- a/pl/catalog.json
+++ b/pl/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Podłączanie Twojego konta...",
     "loading": "Nadal trwa praca..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "Opłata za konwersję {{integrationName}} z {{conversionFromCurrency}} na {{conversionToCurrency}}",
@@ -424,6 +427,8 @@
     "paymentMethodDepositUsage": "Połączona metoda płatności",
     "stablecoinConversion": "Konwersja stablecoin",
     "withAdditional_one": "{{mainOption}} + {{count}} inne",
+    "withAdditional_few": "",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} inne"
   },
   "fundingOptionUnavailabilityReason": {
@@ -718,6 +723,12 @@
     "goBack": "Cofnij",
     "title": "Zapłać kryptowalutą"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Zezwól",
     "movingFunds": "przenoszenie funduszy bez Twojej zgody",
@@ -779,6 +790,11 @@
     "transactionTitle": "Transakcja w toku",
     "tryAgain": "Spróbuj ponownie"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Wprowadź swój {{field}}",
     "fieldErrorWithIntegration": "Wprowadź swój {{integrationName}} {{field}}",
@@ -815,6 +831,15 @@
     "selectAnotherExchange": "Proszę wybrać inny kantor lub portfel, z którego chcesz wpłacić środki.",
     "selectNetwork": "Wybierz sieć transferu",
     "title": "Wybierz aktywo do transferu"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Wszystkie opłaty wliczone",

--- a/pt/catalog.json
+++ b/pt/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Vinculando sua conta...",
     "loading": "Ainda trabalhando..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "Taxa de Conversão {{integrationName}} {{conversionFromCurrency}} para {{conversionToCurrency}}",
@@ -424,6 +427,7 @@
     "paymentMethodDepositUsage": "Método de Pagamento Vinculado",
     "stablecoinConversion": "Conversão de stablecoin",
     "withAdditional_one": "{{mainOption}} + {{count}} outro",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} outros"
   },
   "fundingOptionUnavailabilityReason": {
@@ -718,6 +722,12 @@
     "goBack": "Voltar",
     "title": "Pagar com cripto"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Permitir",
     "movingFunds": "movendo fundos sem sua permissão",
@@ -779,6 +789,11 @@
     "transactionTitle": "Transação em progresso",
     "tryAgain": "Tente novamente"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Por favor, insira seu {{field}}",
     "fieldErrorWithIntegration": "Por favor, insira seu {{integrationName}} {{field}}",
@@ -815,6 +830,15 @@
     "selectAnotherExchange": "Por favor, selecione outro câmbio ou carteira para depósito.",
     "selectNetwork": "Selecione a rede de transferência",
     "title": "Selecione o ativo a ser transferido"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Todas as taxas incluídas",

--- a/ru/catalog.json
+++ b/ru/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Привязка учетной записи...",
     "loading": "Все еще работает..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "Преобразование {{integrationName}} {{conversionFromCurrency}} на {{conversionToCurrency}}",
@@ -424,6 +427,8 @@
     "paymentMethodDepositUsage": "Связанный метод оплаты",
     "stablecoinConversion": "Конверсия Стаблека",
     "withAdditional_one": "{{mainOption}} + {{count}} другой",
+    "withAdditional_few": "",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} других"
   },
   "fundingOptionUnavailabilityReason": {
@@ -718,6 +723,12 @@
     "goBack": "Назад",
     "title": "Оплатить криптовалютой"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Разрешено",
     "movingFunds": "перемещение средств без вашего разрешения",
@@ -779,6 +790,11 @@
     "transactionTitle": "Идет обработка транзакции",
     "tryAgain": "Попробовать еще раз"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Пожалуйста, введите {{field}}",
     "fieldErrorWithIntegration": "Пожалуйста, введите ваш {{field}} {{integrationName}}",
@@ -815,6 +831,15 @@
     "selectAnotherExchange": "Пожалуйста, выберите другой аккаунт или кошелек для перевода.",
     "selectNetwork": "Выберите сеть для перевода",
     "title": "Выберите актив для перевода"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Все сборы включены",

--- a/tr/catalog.json
+++ b/tr/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Hesabınız bağlantılanıyor...",
     "loading": "Hâlâ çalışıyor..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "{{integrationName}} {{conversionFromCurrency}}'den {{conversionToCurrency}}'ye Çevrim Ücreti",
@@ -718,6 +721,12 @@
     "goBack": "Geri git",
     "title": "Kripto ile öde"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "İzin Ver",
     "movingFunds": "izin olmadan fonlarınızı taşımak",
@@ -779,6 +788,11 @@
     "transactionTitle": "İşlem devam ediyor",
     "tryAgain": "Tekrar Dene"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Lütfen {{field}} bilgilerinizi giriniz",
     "fieldErrorWithIntegration": "Lütfen {{integrationName}} {{field}} bilgilerinizi giriniz",
@@ -815,6 +829,15 @@
     "selectAnotherExchange": "Başka bir borsa veya cüzdan seçin.",
     "selectNetwork": "Transfer ağını seçin",
     "title": "Transfer edilecek varlığı seçin"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Tüm ücretler dahil",

--- a/vi/catalog.json
+++ b/vi/catalog.json
@@ -404,6 +404,9 @@
     "linking": "Đang liên kết tài khoản của bạn...",
     "loading": "Vẫn đang làm việc..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "{{integrationName}} {{conversionFromCurrency}} sang {{conversionToCurrency}} Phí chuyển đổi",
@@ -718,6 +721,12 @@
     "goBack": "Quay lại",
     "title": "Thanh toán bằng tiền điện tử"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "Cho phép",
     "movingFunds": "chuyển tiền mà không có sự cho phép của bạn",
@@ -779,6 +788,11 @@
     "transactionTitle": "Giao dịch đang tiến hành",
     "tryAgain": "Thử lại"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "Vui lòng nhập {{field}} của bạn",
     "fieldErrorWithIntegration": "Vui lòng nhập {{field}} {{integrationName}} của bạn",
@@ -815,6 +829,15 @@
     "selectAnotherExchange": "Vui lòng chọn một sàn hoặc ví khác để nạp tiền.",
     "selectNetwork": "Chọn mạng lưới chuyển khoản",
     "title": "Chọn tài sản để chuyển khoản"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "Bao gồm tất cả các khoản phí",

--- a/zh/catalog.json
+++ b/zh/catalog.json
@@ -404,6 +404,9 @@
     "linking": "正在链接您的账户...",
     "loading": "仍在处理中..."
   },
+  "fundingLoadingOverlay": {
+    "loading": ""
+  },
   "fundingMethodFees": {
     "fee": {
       "conversion": "{{integrationName}}从{{conversionFromCurrency}}转换为{{conversionToCurrency}}的转换费",
@@ -718,6 +721,12 @@
     "goBack": "返回",
     "title": "使用加密货币支付"
   },
+  "networkSelectionDrawer": {
+    "description": "",
+    "estimatedGasFeeLabel": "",
+    "lowestFeeLabel": "",
+    "title": ""
+  },
   "nonOAuthPermissionsPage": {
     "allow": "允许",
     "movingFunds": "未经您许可移动资金",
@@ -779,6 +788,11 @@
     "transactionTitle": "交易进行中",
     "tryAgain": "再试一次"
   },
+  "orderSummaryDrawer": {
+    "merchantInfoName": "",
+    "title": "",
+    "totalLabel": ""
+  },
   "passwordPage": {
     "fieldError": "请输入您的{{field}}",
     "fieldErrorWithIntegration": "请输入您的{{integrationName}} {{field}}",
@@ -815,6 +829,15 @@
     "selectAnotherExchange": "请选择另一个可以进行存款的交易所或钱包。",
     "selectNetwork": "选择转账网络",
     "title": "选择要转账的资产"
+  },
+  "previewPageUI": {
+    "accountLabel": "",
+    "includeFeesMessage": "",
+    "networkLabel": "",
+    "paymentTitle": "",
+    "paymentTotalLabel": "",
+    "payWithLabel": "",
+    "payWithLabelWithName": ""
   },
   "previewTransfer": {
     "allFeesIncluded": "所有费用已包括",


### PR DESCRIPTION
- WEB3-770-add-new-translations
- generated new keys in catalag.json files for the translations on the following pages / components:
  - FundingPage
  - PreviewPageUI
  - FundingLoadingOverlay
  - NetworkSelectionDrawer
  - OrderSummaryDrawer
