### PR TITLE
XPR-1439 Show fees properly for SF in wallets 2

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -615,6 +615,7 @@
     "title": "Verification"
   },
   "feesDrawer": {
+    "automatedSwapFeeDescription": "A fee to facilitate an automated swap of assets in your wallet into the target transfer asset.",
     "gasFeeDescription": "The estimated cost to compensate network validators for processing the transaction.",
     "institutionFeeDescription": "This fee covers the network cost for processing your withdrawal. It varies depending on the selected cryptocurrency and current blockchain conditions.",
     "processingFee": "{{clientName}} Processing fee",


### PR DESCRIPTION
TIcket https://meshconnectapi.atlassian.net/browse/XPR-1439

I need to add this part

When an Automated swap fee is shown for the deposit use case, we also need explanatory content that goes beneath it on the page that explains the fees

Text:
A fee to facilitate an automated swap of assets in your wallet into the target transfer asset.

