### PR TITLE
XPR-1439 Add plusFees text

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -1315,6 +1315,7 @@
     "paymentTotalLabel": "Total",
     "payWithLabel": "Pay with",
     "payWithLabelWithName": "Pay with {{integrationName}}",
+    "plusFees": "+ fees",
     "processingPayment": "Processing your payment"
   },
   "previewTransfer": {

--- a/en/catalog.json
+++ b/en/catalog.json
@@ -1315,7 +1315,7 @@
     "paymentTotalLabel": "Total",
     "payWithLabel": "Pay with",
     "payWithLabelWithName": "Pay with {{integrationName}}",
-    "plusFees": "+ fees",
+    "plusFees": "{{amount}} + fees",
     "processingPayment": "Processing your payment"
   },
   "previewTransfer": {


### PR DESCRIPTION
This is a continuation of this ticket https://meshconnectapi.atlassian.net/browse/XPR-1439

how do you wanna show this for wallets where fees might paid in another token? For example should it show...

$21.85 (10.00 USDC + fees) (feels less busy and simpler)

Convo https://meshconnectapi.slack.com/archives/C07DHS3L1RV/p1758212546107559?thread_ts=1758212337.518199&cid=C07DHS3L1RV