### PR TITLE
PRG-2425 update homePage keys for new deposit homepage

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -667,11 +667,16 @@
     "buy": "Buy",
     "buyCrypto": "Buy crypto",
     "buyDescription": "Buy with your card or bank.",
-    "chooseHow": "Choose how to deposit",
-    "connectToWallet": "Connect to wallet or exchange",
+    "buySubtitle": "Buy instantly with your card.",
+    "chooseHow": "Choose how to add money",
+    "chooseHowDeposit": "Choose how to deposit",
+    "connectSubtitle": "Send funds securely to the correct address.",
+    "connectToWallet": "Connect to<1></1>wallet or exchange",
     "connectToWalletLabel": "Connect to wallet or exchange",
+    "depositAgain": "Deposit again in one tap.",
     "guaranteed": "Guaranteed",
     "manualDeposit": "Manual deposit",
+    "manualSubtitle": "Copy an address or scan QR code.",
     "max500": "$500,000 max • Instant",
     "maxVaries": "Maximum varies • 3 mins",
     "minMax": "${{min}} min - ${{max}} max • Instant",
@@ -681,11 +686,7 @@
     "sendFunds": "Send funds safely to the correct address and network.",
     "sendUsingQR": "Send manually using a QR code.",
     "standardDeposit": "Standard deposit",
-    "title": "Add funds",
-    "depositAgain": "Deposit again in one tap.",
-    "connectSubtitle": "Send funds securely to the correct address.",
-    "manualSubtitle": "Copy an address or scan QR code.",
-    "buySubtitle": "Buy instantly with your card."
+    "title": "Add funds"
   },
   "hostedIntegrations": {
     "binance": {

--- a/en/catalog.json
+++ b/en/catalog.json
@@ -676,7 +676,7 @@
     "depositAgain": "Deposit again in one tap.",
     "guaranteed": "Guaranteed",
     "manualDeposit": "Manual deposit",
-    "manualSubtitle": "Copy an address or scan QR code.",
+    "manualSubtitle": "Copy an address or scan a QR code.",
     "max500": "$500,000 max • Instant",
     "maxVaries": "Maximum varies • 3 mins",
     "minMax": "${{min}} min - ${{max}} max • Instant",

--- a/en/catalog.json
+++ b/en/catalog.json
@@ -667,8 +667,8 @@
     "buy": "Buy",
     "buyCrypto": "Buy crypto",
     "buyDescription": "Buy with your card or bank.",
-    "chooseHow": "Choose how to add money",
-    "connectToWallet": "Connect to<1></1>wallet or exchange",
+    "chooseHow": "Choose how to deposit",
+    "connectToWallet": "Connect to wallet or exchange",
     "connectToWalletLabel": "Connect to wallet or exchange",
     "guaranteed": "Guaranteed",
     "manualDeposit": "Manual deposit",
@@ -681,7 +681,11 @@
     "sendFunds": "Send funds safely to the correct address and network.",
     "sendUsingQR": "Send manually using a QR code.",
     "standardDeposit": "Standard deposit",
-    "title": "Add funds"
+    "title": "Add funds",
+    "depositAgain": "Deposit again in one tap.",
+    "connectSubtitle": "Send funds securely to the correct address.",
+    "manualSubtitle": "Copy an address or scan QR code.",
+    "buySubtitle": "Buy instantly with your card."
   },
   "hostedIntegrations": {
     "binance": {


### PR DESCRIPTION
## Summary
Supports PR [front-web-platform#4588](https://github.com/FrontFin/front-web-platform/pull/4588) — the new deposit homepage behind the `newMeshHomePage` feature flag. That PR currently inlines English copy in a `COPY` constant; once this locales PR merges and the submodule pointer is bumped, it'll swap back to `t('homePage.*')` calls.

## Changes (`en/catalog.json` only)

**New keys:**
- `homePage.chooseHowDeposit` - new page title
- `homePage.depositAgain` — subtitle under last-used integration
- `homePage.connectSubtitle` — subtitle under "Connect to wallet or exchange"
- `homePage.manualSubtitle` — subtitle under "Manual deposit"
- `homePage.buySubtitle` — subtitle under "Buy crypto"

Non-English locales are unchanged; Crowdin will pick up the source updates on its next sync.

## Test plan
- [ ] Merge
- [ ] Bump submodule pointer in front-web-platform#4588 and verify the homepage still renders correct strings in `en`
- [ ] Confirm Crowdin picks up the source changes