### PR TITLE
PRG-2483 add insufficientGasBalance error keys

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -1789,6 +1789,8 @@
     "connectAnotherAccount": "Please connect another account.",
     "insufficientBalanceError": "Insufficient balance to fund this transaction.",
     "insufficientFunds": "Insufficient funds",
+    "insufficientGasBalance": "Insufficient gas balance",
+    "insufficientGasBalanceError": "This transaction requires an available balance to transfer plus enough of the network's native asset to pay gas fees.",
     "unknownError": "An unknown error has occurred. Please click below to begin a new transfer session."
   },
   "transferWithdrawalAddressConfirmation": {


### PR DESCRIPTION
Adds title and body strings for the new gas-balance-too-low error case on the transfer preview error page. Used by the FE PRG-2351 change to distinguish insufficient asset balance from insufficient gas, after the BE (PRG-2481) stops collapsing FeeAssetBalanceNotEnough into BalanceNotEnough.