### PR TITLE
PRG-2519 Add payManual.requirements.minimumDeposit/maximumDeposit

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -1198,6 +1198,8 @@
       "includeInTransaction": "Include transfer {{tagLabel}} with deposit",
       "includeInTransactionWithMemo": "Include transfer memo with deposit",
       "includeInTransactionWithTag": "Include transfer tag with deposit",
+      "maximumDeposit": "Maximum deposit: {{amount}} (anything more may result in lost funds)",
+      "minimumDeposit": "Minimum deposit: {{amount}} (anything less may result in lost funds)",
       "sendOnlyTokenOnNetwork": "Send only {{token}} on {{network}}",
       "title": "Requirements",
       "warningText": "Ensure all requirements are met or your funds may be permanently lost."


### PR DESCRIPTION
## Description

Adds two new keys under `payManual.requirements` for the PayManual QR Requirements block:

- `minimumDeposit` — `"Minimum deposit: {{amount}} (anything less may result in lost funds)"`
- `maximumDeposit` — `"Maximum deposit: {{amount}} (anything more may result in lost funds)"`

The FE side renders these whenever the QR response carries per-deposit min/max limits (fiat preferred, crypto fallback). They live alongside the existing `depositMinimum` / `bridgingLimit` rows, which use client-level globals from `/catalog/initial`.

## Dependent PRs

FE companion: FrontFin/front-web-platform PR follows.