### PR TITLE
CEXI-628 Add binanceConnectDepositAddress translations

### DIFF
--- a/de/catalog.json
+++ b/de/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Der Mindestbetrag beträgt {{minAmount}}",
     "switchFiatCrypto": "Fiat/Krypto wechseln"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Der Betrag muss zwischen {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} liegen",
     "completeActionInstruction": "Schließe diese Aktion in deiner Binance-App ab ...",

--- a/en/catalog.json
+++ b/en/catalog.json
@@ -22,6 +22,15 @@
     "switchFiatCrypto": "Switch Fiat/Crypto",
     "unsupportedPair": "This crypto and fiat pair isn't supported."
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "Expires in {{time}}",
+    "failed": "Something went wrong. Please try again.",
+    "qrExpired": "QR code has expired.",
+    "qrLabel": "Binance Connect QR code",
+    "refresh": "Refresh",
+    "scanQr": "Scan this QR code with your Binance app to connect your account.",
+    "tryAgain": "Try Again"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Amount must be within {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Complete this action in your Binance app...",

--- a/es/catalog.json
+++ b/es/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "El monto mínimo es de {{minAmount}}",
     "switchFiatCrypto": "Cambiar Fiat/Cripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "El monto debe estar entre {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Completa esta acción en tu aplicación de Binance...",
@@ -420,6 +429,7 @@
     "incorrect2faCode": "Código de 2FA incorrecto.",
     "incorrectEmail": "Has ingresado un correo electrónico incorrecto.",
     "incorrectPasswordChancesRemaining_one": "Contraseña incorrecta. Tienes {{count}} intento restante.",
+    "incorrectPasswordChancesRemaining_many": "",
     "incorrectPasswordChancesRemaining_other": "Contraseña incorrecta. Te quedan {{count}} intentos.",
     "incorrectUsernameOrPassword": "Nombre de usuario o contraseña incorrectos.",
     "integrationNotAvailable": "La integración no está disponible.",
@@ -576,6 +586,7 @@
     "paymentMethodDepositUsage": "Forma de pago vinculada",
     "stablecoinConversion": "Conversión de stablecoin",
     "withAdditional_one": "{{mainOption}} + {{count}} otro",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} otros"
   },
   "fundingOptionUnavailabilityReason": {

--- a/fi/catalog.json
+++ b/fi/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Pienin sallittu summa on {{minAmount}}",
     "switchFiatCrypto": "Vaihda valuutta/kryptovaluutta"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Määrän on oltava välillä {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Viimeistele tämä toimenpide Binance-sovelluksessasi...",

--- a/fr/catalog.json
+++ b/fr/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Le montant minimum est {{minAmount}}",
     "switchFiatCrypto": "Afficher en : fiat / crypto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Le montant doit être compris entre {{minFiat}} {{selectedFiat}} - et {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Complétez cette action dans votre application Binance...",
@@ -292,7 +301,7 @@
     "transactionHash": "Hash de la transaction {{hash}}"
   },
   "doneTransferPage": {
-    "allSet": "Tout est prêt !",
+    "allSet": "Tout est prêt\u00a0!",
     "checkDetails40": "Voir les détails de la transaction",
     "depositClient": "Vos fonds sont en chemin.",
     "paymentInitiated": "Vous avez initié un paiement de <1></1><2>{{amountCrypto}}</2><3></3> à {{clientName}}",
@@ -420,6 +429,7 @@
     "incorrect2faCode": "Code 2FA incorrect.",
     "incorrectEmail": "Vous avez entré un e-mail incorrect.",
     "incorrectPasswordChancesRemaining_one": "Mot de passe incorrect. Il vous reste {{count}} chance.",
+    "incorrectPasswordChancesRemaining_many": "",
     "incorrectPasswordChancesRemaining_other": "Mot de passe incorrect. Il vous reste {{count}} chances.",
     "incorrectUsernameOrPassword": "Nom d'utilisateur ou mot de passe incorrect.",
     "integrationNotAvailable": "L'intégration n'est pas actuellement disponible.",
@@ -576,6 +586,7 @@
     "paymentMethodDepositUsage": "Méthode de paiement liée",
     "stablecoinConversion": "Conversion de stablecoin",
     "withAdditional_one": "{{mainOption}} + {{count}} autre",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} autres"
   },
   "fundingOptionUnavailabilityReason": {
@@ -1154,15 +1165,15 @@
       "slippage": "Slippage : {{slippage}}"
     },
     "details": {
-      "bridgeFee": "Frais de pont :",
+      "bridgeFee": "Frais de pont\u00a0:",
       "collapsedBridging": "Slippage maximal 0,5 % ; ~{{processingTime}} temps de transfert",
       "collapsedBtcVanilla": "Aucun frais ; moins de 30 min de temps de transfert.",
       "collapsedVanilla": "Aucun frais ; ~1 min temps de transfert",
-      "networkFee": "Frais de réseau :",
+      "networkFee": "Frais de réseau\u00a0:",
       "processingTimeBtcValue": "30 min",
       "processingTimeDefaultValue": "1 min",
       "processingTimeLabel": "Temps de traitement: <{{processingTime}}",
-      "slippage": "Glissement :",
+      "slippage": "Glissement\u00a0:",
       "title": "Détails"
     },
     "entry": {
@@ -1202,7 +1213,7 @@
     },
     "requirements": {
       "addressOneTimeUse": "Adresse à usage unique",
-      "bridgingLimit": "Limite : 2 $ - 500 000 $",
+      "bridgingLimit": "Limite : 2 $ - 500\u00a0000 $",
       "collapsedBridging": "Envoyez {{token}} sur {{network}} ; adresse à usage unique ; limite de 2 $ à 500 000 $.",
       "collapsedFallback": "Assurez-vous que toutes les exigences sont respectées.",
       "collapsedWithMemo": "Envoyez {{token}} sur {{network}}; adresse à usage unique; inclure le mémo.",
@@ -1268,7 +1279,7 @@
   "payPage": {
     "amountMustBeWithin": "Le montant doit être compris entre {{minFiat}} - {{maxFiat}}",
     "bybit": {
-      "fee": "Frais : {{fee}}"
+      "fee": "Frais\u00a0: {{fee}}"
     },
     "continueInPayApp": "",
     "cryptoCom": {

--- a/hi/catalog.json
+++ b/hi/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "न्यूनतम राशि {{minAmount}} है।",
     "switchFiatCrypto": "फिएट/क्रिप्टो स्विच करें"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "राशि {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} के भीतर होनी चाहिए",
     "completeActionInstruction": "इस कार्रवाई को अपने Binance ऐप में पूरा करें...",

--- a/id/catalog.json
+++ b/id/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Jumlah minimum adalah {{minAmount}}",
     "switchFiatCrypto": "Tukar Fiat/Kripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Jumlah harus antara {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Selesaikan tindakan ini di aplikasi Binance Anda...",

--- a/ja/catalog.json
+++ b/ja/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "最小金額は {{minAmount}} です",
     "switchFiatCrypto": "法定通貨／暗号通貨を切り替える"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "金額は{{minFiat}} {{selectedFiat}} から {{maxFiat}} {{selectedFiat}} の範囲内である必要があります",
     "completeActionInstruction": "Binanceアプリでこの操作を完了してください。。。",

--- a/ms/catalog.json
+++ b/ms/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Jumlah minimum ialah {{minAmount}}",
     "switchFiatCrypto": "Tukar Fiat/Kripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Jumlah mesti antara {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Selesaikan tindakan ini dalam aplikasi Binance anda...",

--- a/pl/catalog.json
+++ b/pl/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Minimalna kwota to {{minAmount}}",
     "switchFiatCrypto": "Przełącz Fiat/Krypto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Kwota musi mieścić się w przedziale {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Dokończ tę czynność w aplikacji Binance...",
@@ -420,6 +429,8 @@
     "incorrect2faCode": "Nieprawidłowy kod 2FA.",
     "incorrectEmail": "Wprowadzono niepoprawny email.",
     "incorrectPasswordChancesRemaining_one": "Niepoprawne hasło. Pozostała {{count}} próba.",
+    "incorrectPasswordChancesRemaining_few": "",
+    "incorrectPasswordChancesRemaining_many": "",
     "incorrectPasswordChancesRemaining_other": "Niepoprawne hasło. Pozostało {{count}} prób.",
     "incorrectUsernameOrPassword": "Niepoprawna nazwa użytkownika lub hasło.",
     "integrationNotAvailable": "Obecnie integracja nie jest dostępna.",
@@ -576,6 +587,8 @@
     "paymentMethodDepositUsage": "Powiązana metoda płatności",
     "stablecoinConversion": "Przeliczenie stablecoin‘a",
     "withAdditional_one": "{{mainOption}} + {{count}} innych",
+    "withAdditional_few": "",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} inne/innych"
   },
   "fundingOptionUnavailabilityReason": {

--- a/pt/catalog.json
+++ b/pt/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "A quantidade mínima é {{minAmount}}",
     "switchFiatCrypto": "Trocar Fiat/Cripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "O valor deve estar entre {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Conclui esta ação na aplicação da Binance...",
@@ -420,6 +429,7 @@
     "incorrect2faCode": "Código 2FA incorreto.",
     "incorrectEmail": "Inseriste um email incorreto.",
     "incorrectPasswordChancesRemaining_one": "Senha incorreta. Tens {{count}} tentativa restante.",
+    "incorrectPasswordChancesRemaining_many": "",
     "incorrectPasswordChancesRemaining_other": "Senha incorreta. Tens {{count}} tentativas restantes.",
     "incorrectUsernameOrPassword": "Nome de utilizador ou palavra-passe incorreta.",
     "integrationNotAvailable": "A integração não está disponível no momento.",
@@ -576,6 +586,7 @@
     "paymentMethodDepositUsage": "Método de Pagamento Confirmado",
     "stablecoinConversion": "Conversão de stablecoin",
     "withAdditional_one": "{{mainOption}} + {{count}} outro",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} outros"
   },
   "fundingOptionUnavailabilityReason": {

--- a/ru/catalog.json
+++ b/ru/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Минимальная сумма - {{minAmount}}",
     "switchFiatCrypto": "Переключить Валюта/Крипто"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Сумма должна быть в пределах {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Завершите это действие в приложении Binance...",
@@ -420,6 +429,8 @@
     "incorrect2faCode": "Неверный код 2FA.",
     "incorrectEmail": "Вы ввели неверный адрес электронной почты.",
     "incorrectPasswordChancesRemaining_one": "Неверный пароль. У вас осталась {{count}} попытка.",
+    "incorrectPasswordChancesRemaining_few": "",
+    "incorrectPasswordChancesRemaining_many": "",
     "incorrectPasswordChancesRemaining_other": "Неверный пароль. У вас осталось {{count}} попыток.",
     "incorrectUsernameOrPassword": "Неверное имя пользователя или пароль.",
     "integrationNotAvailable": "Интеграция в настоящее время недоступна.",
@@ -576,6 +587,8 @@
     "paymentMethodDepositUsage": "Связанный метод оплаты",
     "stablecoinConversion": "Конверсия Стаблека",
     "withAdditional_one": "{{mainOption}} + {{count}} другой",
+    "withAdditional_few": "",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} других"
   },
   "fundingOptionUnavailabilityReason": {

--- a/th/catalog.json
+++ b/th/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "จำนวนขั้นต่ำคือ {{minAmount}}",
     "switchFiatCrypto": "เปลี่ยนสกุลเงินปกติกับคริปโต"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "จำนวนต้องอยู่ในระหว่าง {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "เสร็จสิ้นการดำเนินการนี้ในแอป Binance ของคุณ...",

--- a/tr/catalog.json
+++ b/tr/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Minimum tutar {{minAmount}}",
     "switchFiatCrypto": "Fiat/Kripto değiştir"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Miktar {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} arasında olmalıdır",
     "completeActionInstruction": "Bu işlemi Binance uygulamanızda tamamlayın...",

--- a/uk/catalog.json
+++ b/uk/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Мінімальна сума {{minAmount}}",
     "switchFiatCrypto": "Перемикання Fiat/Crypto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Сума повинна бути в межах {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Завершіть цю дію у своєму додатку Binance...",
@@ -420,6 +429,8 @@
     "incorrect2faCode": "Невірний код 2FA.",
     "incorrectEmail": "Ви ввели неправильний електронний адрес.",
     "incorrectPasswordChancesRemaining_one": "Неправильний пароль. У вас {{count}} спроба залишилась.",
+    "incorrectPasswordChancesRemaining_few": "",
+    "incorrectPasswordChancesRemaining_many": "",
     "incorrectPasswordChancesRemaining_other": "Неправильний пароль. У вас залишилось {{count}} спроб.",
     "incorrectUsernameOrPassword": "Неправильне ім'я користувача або пароль.",
     "integrationNotAvailable": "Інтеграція наразі недоступна.",
@@ -576,6 +587,8 @@
     "paymentMethodDepositUsage": "Пов'язаний платіжний метод",
     "stablecoinConversion": "Конверсія стейблкоїнів",
     "withAdditional_one": "{{mainOption}} + {{count}} інший",
+    "withAdditional_few": "",
+    "withAdditional_many": "",
     "withAdditional_other": "{{mainOption}} + {{count}} інші"
   },
   "fundingOptionUnavailabilityReason": {

--- a/uz/catalog.json
+++ b/uz/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Minimal miqdor {{minAmount}}",
     "switchFiatCrypto": "Pul o'lchovi/Kriptovalyuta almash"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Miqdor {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} oralig'ida bo'lishi kerak",
     "completeActionInstruction": "Bu amalni Binance ilovangizda yakunlang...",

--- a/vi/catalog.json
+++ b/vi/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "Số tiền tối thiểu là {{minAmount}}",
     "switchFiatCrypto": "Chuyển đổi Tiền pháp định/Mã hoá"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Số tiền phải nằm trong khoảng {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Vui lòng hoàn tất thao tác này trong ứng dụng Binance của bạn...",

--- a/zh/catalog.json
+++ b/zh/catalog.json
@@ -18,6 +18,15 @@
     "minimumAmount": "最小转账金额为 {{minAmount}}",
     "switchFiatCrypto": "切换法币/加密货币"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "",
+    "failed": "",
+    "qrExpired": "",
+    "qrLabel": "",
+    "refresh": "",
+    "scanQr": "",
+    "tryAgain": ""
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "金额必须在{{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}之间",
     "completeActionInstruction": "在您的币安应用中完成此步骤...",


### PR DESCRIPTION
## Summary
- Adds `binanceConnectDepositAddress` translation keys for the new Binance Connect deposit QR code page
- English strings filled in; other languages scaffolded as empty stubs for translation pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)