### PR TITLE
CEXI-628 Add binanceConnectDepositAddress translations

### DIFF
--- a/de/catalog.json
+++ b/de/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Der Mindestbetrag beträgt {{minAmount}}",
     "switchFiatCrypto": "Fiat/Krypto wechseln"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "QR-Code konnte nicht geladen werden",
+    "qrExpired": "QR-Code abgelaufen",
+    "qrLabel": "Autorisierungs-QR-Code",
+    "refresh": "Aktualisieren",
+    "scanQr": "Öffne deine Binance-App und scanne diesen Code, um fortzufahren.",
+    "title": "Zum Autorisieren scannen",
+    "tryAgain": "Erneut versuchen"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Der Betrag muss zwischen {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} liegen",
     "completeActionInstruction": "Schließe diese Aktion in deiner Binance-App ab ...",

--- a/en/catalog.json
+++ b/en/catalog.json
@@ -22,6 +22,16 @@
     "switchFiatCrypto": "Switch Fiat/Crypto",
     "unsupportedPair": "This crypto and fiat pair isn't supported."
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Failed to load QR code",
+    "qrExpired": "QR code expired",
+    "qrLabel": "Authorization QR code",
+    "refresh": "Refresh",
+    "scanQr": "Open your Binance app and scan this code to continue.",
+    "title": "Scan to authorize",
+    "tryAgain": "Try again"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Amount must be within {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Complete this action in your Binance app...",

--- a/es/catalog.json
+++ b/es/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "El monto mínimo es de {{minAmount}}",
     "switchFiatCrypto": "Cambiar Fiat/Cripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "No se pudo cargar el código QR",
+    "qrExpired": "Código QR expirado",
+    "qrLabel": "Código QR de autorización",
+    "refresh": "Actualizar",
+    "scanQr": "Abre tu app de Binance y escanea este código para continuar.",
+    "title": "Escanear para autorizar",
+    "tryAgain": "Intentar de nuevo"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "El monto debe estar entre {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Completa esta acción en tu aplicación de Binance...",

--- a/fi/catalog.json
+++ b/fi/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Pienin sallittu summa on {{minAmount}}",
     "switchFiatCrypto": "Vaihda valuutta/kryptovaluutta"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "QR-koodin lataaminen epäonnistui",
+    "qrExpired": "QR-koodi vanhentunut",
+    "qrLabel": "Valtuutus-QR-koodi",
+    "refresh": "Päivitä",
+    "scanQr": "Avaa Binance-sovellus ja skannaa tämä koodi jatkaaksesi.",
+    "title": "Skannaa valtuuttaaksesi",
+    "tryAgain": "Yritä uudelleen"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Määrän on oltava välillä {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Viimeistele tämä toimenpide Binance-sovelluksessasi...",

--- a/fr/catalog.json
+++ b/fr/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Le montant minimum est {{minAmount}}",
     "switchFiatCrypto": "Afficher en : fiat / crypto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Impossible de charger le code QR",
+    "qrExpired": "Code QR expiré",
+    "qrLabel": "Code QR d'autorisation",
+    "refresh": "Actualiser",
+    "scanQr": "Ouvrez votre application Binance et scannez ce code pour continuer.",
+    "title": "Scanner pour autoriser",
+    "tryAgain": "Réessayer"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Le montant doit être compris entre {{minFiat}} {{selectedFiat}} - et {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Complétez cette action dans votre application Binance...",

--- a/hi/catalog.json
+++ b/hi/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "न्यूनतम राशि {{minAmount}} है।",
     "switchFiatCrypto": "फिएट/क्रिप्टो स्विच करें"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "QR कोड लोड नहीं हो सका",
+    "qrExpired": "QR कोड समाप्त हो गया",
+    "qrLabel": "प्राधिकरण QR कोड",
+    "refresh": "रीफ्रेश करें",
+    "scanQr": "अपना Binance ऐप खोलें और जारी रखने के लिए इस कोड को स्कैन करें।",
+    "title": "अधिकृत करने के लिए स्कैन करें",
+    "tryAgain": "पुनः प्रयास करें"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "राशि {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} के भीतर होनी चाहिए",
     "completeActionInstruction": "इस कार्रवाई को अपने Binance ऐप में पूरा करें...",

--- a/id/catalog.json
+++ b/id/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Jumlah minimum adalah {{minAmount}}",
     "switchFiatCrypto": "Tukar Fiat/Kripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Gagal memuat kode QR",
+    "qrExpired": "Kode QR kedaluwarsa",
+    "qrLabel": "Kode QR otorisasi",
+    "refresh": "Segarkan",
+    "scanQr": "Buka aplikasi Binance Anda dan pindai kode ini untuk melanjutkan.",
+    "title": "Pindai untuk otorisasi",
+    "tryAgain": "Coba lagi"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Jumlah harus antara {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Selesaikan tindakan ini di aplikasi Binance Anda...",

--- a/ja/catalog.json
+++ b/ja/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "最小金額は {{minAmount}} です",
     "switchFiatCrypto": "法定通貨／暗号通貨を切り替える"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "QRコードを読み込めませんでした",
+    "qrExpired": "QRコードの有効期限が切れました",
+    "qrLabel": "認証QRコード",
+    "refresh": "更新",
+    "scanQr": "Binanceアプリを開き、このコードをスキャンして続行してください。",
+    "title": "スキャンして承認",
+    "tryAgain": "もう一度試す"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "金額は{{minFiat}} {{selectedFiat}} から {{maxFiat}} {{selectedFiat}} の範囲内である必要があります",
     "completeActionInstruction": "Binanceアプリでこの操作を完了してください。。。",

--- a/ms/catalog.json
+++ b/ms/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Jumlah minimum ialah {{minAmount}}",
     "switchFiatCrypto": "Tukar Fiat/Kripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Gagal memuatkan kod QR",
+    "qrExpired": "Kod QR telah tamat tempoh",
+    "qrLabel": "Kod QR kebenaran",
+    "refresh": "Muat semula",
+    "scanQr": "Buka apl Binance anda dan imbas kod ini untuk meneruskan.",
+    "title": "Imbas untuk memberi kebenaran",
+    "tryAgain": "Cuba lagi"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Jumlah mesti antara {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Selesaikan tindakan ini dalam aplikasi Binance anda...",

--- a/pl/catalog.json
+++ b/pl/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Minimalna kwota to {{minAmount}}",
     "switchFiatCrypto": "Przełącz Fiat/Krypto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Nie udało się załadować kodu QR",
+    "qrExpired": "Kod QR wygasł",
+    "qrLabel": "Kod QR autoryzacji",
+    "refresh": "Odśwież",
+    "scanQr": "Otwórz aplikację Binance i zeskanuj ten kod, aby kontynuować.",
+    "title": "Zeskanuj, aby autoryzować",
+    "tryAgain": "Spróbuj ponownie"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Kwota musi mieścić się w przedziale {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Dokończ tę czynność w aplikacji Binance...",

--- a/pt/catalog.json
+++ b/pt/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "A quantidade mínima é {{minAmount}}",
     "switchFiatCrypto": "Trocar Fiat/Cripto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Falha ao carregar o código QR",
+    "qrExpired": "Código QR expirado",
+    "qrLabel": "Código QR de autorização",
+    "refresh": "Atualizar",
+    "scanQr": "Abra o seu app Binance e escaneie este código para continuar.",
+    "title": "Escanear para autorizar",
+    "tryAgain": "Tentar novamente"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "O valor deve estar entre {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Conclui esta ação na aplicação da Binance...",

--- a/ru/catalog.json
+++ b/ru/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Минимальная сумма - {{minAmount}}",
     "switchFiatCrypto": "Переключить Валюта/Крипто"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Не удалось загрузить QR-код",
+    "qrExpired": "QR-код истёк",
+    "qrLabel": "QR-код авторизации",
+    "refresh": "Обновить",
+    "scanQr": "Откройте приложение Binance и отсканируйте этот код, чтобы продолжить.",
+    "title": "Сканировать для авторизации",
+    "tryAgain": "Попробовать снова"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Сумма должна быть в пределах {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Завершите это действие в приложении Binance...",

--- a/th/catalog.json
+++ b/th/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "จำนวนขั้นต่ำคือ {{minAmount}}",
     "switchFiatCrypto": "เปลี่ยนสกุลเงินปกติกับคริปโต"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "ไม่สามารถโหลด QR code ได้",
+    "qrExpired": "QR code หมดอายุแล้ว",
+    "qrLabel": "QR code สำหรับการอนุมัติ",
+    "refresh": "รีเฟรช",
+    "scanQr": "เปิดแอป Binance ของคุณและสแกนรหัสนี้เพื่อดำเนินการต่อ",
+    "title": "สแกนเพื่ออนุมัติ",
+    "tryAgain": "ลองอีกครั้ง"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "จำนวนต้องอยู่ในระหว่าง {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "เสร็จสิ้นการดำเนินการนี้ในแอป Binance ของคุณ...",

--- a/tr/catalog.json
+++ b/tr/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Minimum tutar {{minAmount}}",
     "switchFiatCrypto": "Fiat/Kripto değiştir"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "QR kodu yüklenemedi",
+    "qrExpired": "QR kodun süresi doldu",
+    "qrLabel": "Yetkilendirme QR kodu",
+    "refresh": "Yenile",
+    "scanQr": "Binance uygulamanızı açın ve devam etmek için bu kodu tarayın.",
+    "title": "Yetkilendirmek için tarayın",
+    "tryAgain": "Tekrar dene"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Miktar {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} arasında olmalıdır",
     "completeActionInstruction": "Bu işlemi Binance uygulamanızda tamamlayın...",

--- a/uk/catalog.json
+++ b/uk/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Мінімальна сума {{minAmount}}",
     "switchFiatCrypto": "Перемикання Fiat/Crypto"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Не вдалося завантажити QR-код",
+    "qrExpired": "QR-код застарів",
+    "qrLabel": "QR-код авторизації",
+    "refresh": "Оновити",
+    "scanQr": "Відкрийте додаток Binance і відскануйте цей код, щоб продовжити.",
+    "title": "Сканувати для авторизації",
+    "tryAgain": "Спробувати знову"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Сума повинна бути в межах {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Завершіть цю дію у своєму додатку Binance...",

--- a/uz/catalog.json
+++ b/uz/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Minimal miqdor {{minAmount}}",
     "switchFiatCrypto": "Pul o'lchovi/Kriptovalyuta almash"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "QR kodni yuklab bo'lmadi",
+    "qrExpired": "QR kod muddati tugagan",
+    "qrLabel": "Avtorizatsiya QR kodi",
+    "refresh": "Yangilash",
+    "scanQr": "Binance ilovangizni oching va davom etish uchun ushbu kodni skanerlang.",
+    "title": "Avtorizatsiya uchun skaner qiling",
+    "tryAgain": "Qayta urinish"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Miqdor {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}} oralig'ida bo'lishi kerak",
     "completeActionInstruction": "Bu amalni Binance ilovangizda yakunlang...",

--- a/vi/catalog.json
+++ b/vi/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "Số tiền tối thiểu là {{minAmount}}",
     "switchFiatCrypto": "Chuyển đổi Tiền pháp định/Mã hoá"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "Không thể tải mã QR",
+    "qrExpired": "Mã QR đã hết hạn",
+    "qrLabel": "Mã QR ủy quyền",
+    "refresh": "Làm mới",
+    "scanQr": "Mở ứng dụng Binance và quét mã này để tiếp tục.",
+    "title": "Quét để ủy quyền",
+    "tryAgain": "Thử lại"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "Số tiền phải nằm trong khoảng {{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}",
     "completeActionInstruction": "Vui lòng hoàn tất thao tác này trong ứng dụng Binance của bạn...",

--- a/zh/catalog.json
+++ b/zh/catalog.json
@@ -18,6 +18,16 @@
     "minimumAmount": "最小转账金额为 {{minAmount}}",
     "switchFiatCrypto": "切换法币/加密货币"
   },
+  "binanceConnectDepositAddress": {
+    "expiresIn": "{{time}}",
+    "failed": "无法加载二维码",
+    "qrExpired": "二维码已过期",
+    "qrLabel": "授权二维码",
+    "refresh": "刷新",
+    "scanQr": "打开您的Binance应用并扫描此码以继续。",
+    "title": "扫描以授权",
+    "tryAgain": "重试"
+  },
   "binanceConnectOAuthPage": {
     "amountMustBeWithin": "金额必须在{{minFiat}} {{selectedFiat}} - {{maxFiat}} {{selectedFiat}}之间",
     "completeActionInstruction": "在您的币安应用中完成此步骤...",


### PR DESCRIPTION
## Summary
- Populate the previously-empty `binanceConnectDepositAddress.*` keys (expiresIn, failed, qrExpired, qrLabel, refresh, scanQr, tryAgain) with English copy across all locale files
- Add a new `title` key for the "Deposit from your app" heading

Pairs with https://github.com/FrontFin/front-web-platform/pull/4752 — the front-web-platform PR cannot bump the submodule pointer until this lands on `main` here.