### PR TITLE
PRG-3046 Add feesDrawer additionalFees translations

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -538,6 +538,8 @@
     "title": "Verification"
   },
   "feesDrawer": {
+    "additionalFees": "Additional fees",
+    "additionalFeesDescription": "Other fees included in your total.",
     "autoConvertBridgingFeeDescription": "Includes all conversion fees and a small slippage buffer. You’ll never pay more than the amount shown.",
     "autoConvertBridgingFeeTooltipDescription": "This fee covers the cost of converting and transferring your funds across networks using our bridging partner. It includes relayer fees, routing costs, and any cross-network execution fees needed to complete your transfer. A small slippage buffer is included to protect your transfer from price changes during execution. You will never pay more than the fee amount shown — if the full buffer is not used, you are charged less automatically.",
     "automatedSwapFeeDescription": "A fee to facilitate an automated swap of assets in your wallet into the target transfer asset.",


### PR DESCRIPTION
Adds English source strings for the reconciliation "Additional fees" row in the transfer fee breakdown (`FeesDrawer`), part of the PRG-3046 fix (Revolut fee discrepancy — CARE-257).

English-only per the Crowdin workflow; Crowdin will populate the other 17 locales via its `l18n_main` PR. Consumed by front-web-platform `FeesDrawer.tsx` as `feesDrawer.additionalFees` / `feesDrawer.additionalFeesDescription`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)