### PR TITLE
PRG-3157: add no-symbol gas-balance copy variants (en)

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -1439,11 +1439,11 @@
       "hint": "Choose a different network or add {{gasSymbol}} to your wallet and try again.",
       "hintNoSymbol": "Choose a different network or add more funds to your wallet and try again.",
       "message": "This transaction requires {{transferAmount}} and ~{{gasFiat}} worth of {{gasSymbol}} to pay gas fees.",
-      "messageNoSymbol": "This transaction requires {{transferAmount}} and ~{{gasFiat}} to pay gas fees."
+      "messageNoSymbol": "This transaction requires {{transferAmount}} and ~{{gasFiat}} in gas fees."
     },
     "insufficientGasBalancePage": {
       "message": "This transaction requires {{transferAmount}} and ~{{gasFiat}} worth of {{gasSymbol}} on the {{networkName}} network to pay gas fees.",
-      "messageNoSymbol": "This transaction requires {{transferAmount}} and ~{{gasFiat}} to pay gas fees on the {{networkName}} network.",
+      "messageNoSymbol": "This transaction requires {{transferAmount}} and ~{{gasFiat}} in gas fees on the {{networkName}} network.",
       "title": "Insufficient gas balance"
     },
     "inWalletBrowserInitialPage": {

--- a/en/catalog.json
+++ b/en/catalog.json
@@ -1437,10 +1437,13 @@
     },
     "insufficientGasBalanceNetworksPage": {
       "hint": "Choose a different network or add {{gasSymbol}} to your wallet and try again.",
-      "message": "This transaction requires {{transferAmount}} and ~{{gasFiat}} worth of {{gasSymbol}} to pay gas fees."
+      "hintNoSymbol": "Choose a different network or add more funds to your wallet and try again.",
+      "message": "This transaction requires {{transferAmount}} and ~{{gasFiat}} worth of {{gasSymbol}} to pay gas fees.",
+      "messageNoSymbol": "This transaction requires {{transferAmount}} and ~{{gasFiat}} to pay gas fees."
     },
     "insufficientGasBalancePage": {
       "message": "This transaction requires {{transferAmount}} and ~{{gasFiat}} worth of {{gasSymbol}} on the {{networkName}} network to pay gas fees.",
+      "messageNoSymbol": "This transaction requires {{transferAmount}} and ~{{gasFiat}} to pay gas fees on the {{networkName}} network.",
       "title": "Insufficient gas balance"
     },
     "inWalletBrowserInitialPage": {


### PR DESCRIPTION
## Summary

Adds no-symbol copy variants for the PayPal "Insufficient gas balance" screens so the message reads cleanly when the gas token symbol is blank.

New keys under `paypal`:
- `insufficientGasBalancePage.messageNoSymbol`
- `insufficientGasBalanceNetworksPage.messageNoSymbol`
- `insufficientGasBalanceNetworksPage.hintNoSymbol`

## Context

Consumed by front-web-platform PR #4807 (PRG-3157). English only; other locales fall through to EN via i18next until translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
