### PR TITLE
CEXI-891: add transfer-failed and transfer-processing catalog copy (en)

### DIFF
--- a/en/catalog.json
+++ b/en/catalog.json
@@ -677,7 +677,11 @@
     "recievedDetails": "You will receive <1>{{amountStr}}</1> in {{clientName}} ({{shortAddress}})",
     "requestRecieved": "Your request to transfer to {{destination}} was received by {{selectedIntegrationName}}",
     "revolutApproveInfo": "This transfer will not be initiated until it is approved in Revolut app",
-    "transactionComplete": "Transaction complete"
+    "transactionComplete": "Transaction complete",
+    "transferFailed": "Your transfer could not be completed. Please try again.",
+    "transferFailedTitle": "Transfer failed",
+    "transferProcessingBody": "Wait here or close this safely. Your transfer will keep processing.",
+    "transferProcessingTitle": "Your transfer is processing"
   },
   "handleOauthPage": {
     "error": "Failed to link your account. {{error}}"


### PR DESCRIPTION
## Summary
Adds English catalog copy for the new on-ramp transfer outcome screens introduced in front-web-platform (CEXI-891):

- `handleExternalTransferPage.transferFailedTitle` — "Transfer failed"
- `handleExternalTransferPage.transferFailed` — "Your transfer could not be completed. Please try again."
- `handleExternalTransferPage.transferProcessingTitle` — "Your transfer is processing"
- `handleExternalTransferPage.transferProcessingBody` — "Wait here or close this safely. Your transfer will keep processing."

## Context
Consumed by the `front-web-platform` branch `bugfix/cexi-891-transfer-failed-page`, which renders a dedicated transfer-failed page (distinct from a connection failure) and a neutral transfer-processing page for on-ramp transfers (Binance Connect, Robinhood, etc.). Port of link-v2 PR #463.

Once merged, the front-web-platform submodule pointer will be bumped to include these keys (its `locales:types` CI check depends on them).

## Changes
- `en/catalog.json`: +4 keys under `handleExternalTransferPage` (additive; based on current `main` at cf1f27b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)